### PR TITLE
added note to address ember server issue

### DIFF
--- a/app/templates/resources/intermediate/workshop-notes.hbs
+++ b/app/templates/resources/intermediate/workshop-notes.hbs
@@ -36,6 +36,8 @@
 
 <p>Keep the server running and open a new instance of your terminal and cd to the location of your ember application so that we still have access to the command line to use all of Ember-CLI’s command line tools.</p>
 
+<p>Note ** If ember has not been installed globally, you may need to start the server using <strong>ember server</strong>.</p>
+
 <hr>
 
 


### PR DESCRIPTION
"ember serve" doesn't always work as a method to start up the server.

If you have not installed ember globally this can cause issues, so I think it makes sense to have a note mentioning another method to get things going, such as "ember server". 
